### PR TITLE
Feature/#2 authentication entity

### DIFF
--- a/src/main/java/com/demo/pteam/authentication/repository/converter/AccountStatusConverter.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/converter/AccountStatusConverter.java
@@ -1,0 +1,18 @@
+package com.demo.pteam.authentication.repository.converter;
+
+import com.demo.pteam.authentication.service.domain.AccountStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class AccountStatusConverter implements AttributeConverter<AccountStatus, Byte> {
+    @Override
+    public Byte convertToDatabaseColumn(AccountStatus status) {
+        return AccountStatus.getCode(status);
+    }
+
+    @Override
+    public AccountStatus convertToEntityAttribute(Byte code) {
+        return AccountStatus.getType(code);
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/repository/converter/RoleConverter.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/converter/RoleConverter.java
@@ -1,0 +1,18 @@
+package com.demo.pteam.authentication.repository.converter;
+
+import com.demo.pteam.authentication.service.domain.Role;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class RoleConverter implements AttributeConverter<Role, Byte> {
+    @Override
+    public Byte convertToDatabaseColumn(Role role) {
+        return Role.getCode(role);
+    }
+
+    @Override
+    public Role convertToEntityAttribute(Byte code) {
+        return Role.getType(code);
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/repository/converter/SocialTypeConverter.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/converter/SocialTypeConverter.java
@@ -1,0 +1,18 @@
+package com.demo.pteam.authentication.repository.converter;
+
+import com.demo.pteam.authentication.service.domain.SocialType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class SocialTypeConverter implements AttributeConverter<SocialType, Byte> {
+    @Override
+    public Byte convertToDatabaseColumn(SocialType type) {
+        return SocialType.getCode(type);
+    }
+
+    @Override
+    public SocialType convertToEntityAttribute(Byte code) {
+        return SocialType.getType(code);
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/repository/entity/AccountEntity.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/entity/AccountEntity.java
@@ -1,0 +1,42 @@
+package com.demo.pteam.authentication.repository.entity;
+
+import com.demo.pteam.authentication.repository.converter.RoleConverter;
+import com.demo.pteam.authentication.service.domain.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "accounts")
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn(name = "entity_type", discriminatorType = DiscriminatorType.INTEGER)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public abstract class AccountEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String nickname;
+
+    @Convert(converter = RoleConverter.class)
+    @Column(updatable = false)
+    private Role role;
+
+    // TODO: 임시 구현
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Column(insertable = false)
+    private LocalDateTime deletedAt;
+
+    protected AccountEntity(String name, String nickname, Role role) {
+        this.name = name;
+        this.nickname = nickname;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/repository/entity/LocalAccountEntity.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/entity/LocalAccountEntity.java
@@ -1,0 +1,38 @@
+package com.demo.pteam.authentication.repository.entity;
+
+import com.demo.pteam.authentication.repository.converter.AccountStatusConverter;
+import com.demo.pteam.authentication.service.domain.AccountStatus;
+import com.demo.pteam.authentication.service.domain.Role;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "local_accounts")
+@DiscriminatorValue(value = "1")
+@PrimaryKeyJoinColumn(name = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LocalAccountEntity extends AccountEntity {
+    @Column(updatable = false)
+    private String username;
+    private String password;
+    private String email;
+
+    @Convert(converter = AccountStatusConverter.class)
+    private AccountStatus status;
+
+    @Column(insertable = false, updatable = false)
+    private String activeUsername;
+
+    @Builder
+    public LocalAccountEntity(String name, String nickname, Role role, String username, String password, String email, AccountStatus status) {
+        super(name, nickname, role);
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/repository/entity/SocialAccountEntity.java
+++ b/src/main/java/com/demo/pteam/authentication/repository/entity/SocialAccountEntity.java
@@ -1,0 +1,39 @@
+package com.demo.pteam.authentication.repository.entity;
+
+import com.demo.pteam.authentication.repository.converter.AccountStatusConverter;
+import com.demo.pteam.authentication.repository.converter.SocialTypeConverter;
+import com.demo.pteam.authentication.service.domain.AccountStatus;
+import com.demo.pteam.authentication.service.domain.Role;
+import com.demo.pteam.authentication.service.domain.SocialType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "social_accounts")
+@DiscriminatorValue(value = "2")
+@PrimaryKeyJoinColumn(name = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SocialAccountEntity extends AccountEntity {
+    private String usernameCode;
+
+    @Convert(converter = SocialTypeConverter.class)
+    private SocialType type;
+
+    @Convert(converter = AccountStatusConverter.class)
+    private AccountStatus status;
+
+    @Column(insertable = false, updatable = false)
+    private String activeUsernameCode;
+
+    @Builder
+    public SocialAccountEntity(String name, String nickname, Role role, String usernameCode, SocialType type, AccountStatus status) {
+        super(name, nickname, role);
+        this.usernameCode = usernameCode;
+        this.type = type;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
@@ -1,0 +1,34 @@
+package com.demo.pteam.authentication.service.domain;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum AccountStatus {
+    LOCAL(1),
+    SOCIAL(2);
+
+    private final byte code;
+    private static final Map<Byte, AccountStatus> CODE_MAP =
+            Arrays.stream(AccountStatus.values())
+                    .collect(Collectors.toUnmodifiableMap(v -> v.getCode(), Function.identity()));
+
+    AccountStatus(int code) {
+        this.code = (byte) code;
+    }
+
+    public Byte getCode() {
+        return code;
+    }
+
+    public static Byte getCode(AccountStatus type) {
+        return Objects.requireNonNull(type, "AccountStatus is null").getCode();
+    }
+
+    public static AccountStatus getType(Byte code) {
+        Objects.requireNonNull(code, "code is null");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found AccountStatus");
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
@@ -29,6 +29,6 @@ public enum AccountStatus {
 
     public static AccountStatus getType(Byte code) {
         Objects.requireNonNull(code, "code is null");
-        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found AccountStatus");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Invalid code! Not Found AccountStatus");
     }
 }

--- a/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/AccountStatus.java
@@ -7,8 +7,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public enum AccountStatus {
-    LOCAL(1),
-    SOCIAL(2);
+    DELETED(-1),    // 삭제
+    SUSPENDED(0),   // 정지
+    ACTIVE(1),      // 활성
+    UNVERIFIED(2);  // 미인증
+
 
     private final byte code;
     private static final Map<Byte, AccountStatus> CODE_MAP =

--- a/src/main/java/com/demo/pteam/authentication/service/domain/Role.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/Role.java
@@ -1,0 +1,34 @@
+package com.demo.pteam.authentication.service.domain;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Role {
+    ROLE_USER(1),
+    ROLE_TRAINER(2);
+
+    private final byte code;
+    private static final Map<Byte, Role> CODE_MAP =
+            Arrays.stream(Role.values())
+                    .collect(Collectors.toUnmodifiableMap(v -> v.getCode(), Function.identity()));
+
+    Role(int code) {
+        this.code = (byte) code;
+    }
+
+    public Byte getCode() {
+        return code;
+    }
+
+    public static Byte getCode(Role role) {
+        return Objects.requireNonNull(role, "Role is null").getCode();
+    }
+
+    public static Role getType(Byte code) {
+        Objects.requireNonNull(code, "code is null");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found Role");
+    }
+}

--- a/src/main/java/com/demo/pteam/authentication/service/domain/Role.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/Role.java
@@ -29,6 +29,6 @@ public enum Role {
 
     public static Role getType(Byte code) {
         Objects.requireNonNull(code, "code is null");
-        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found Role");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Invalid code! Not Found Role");
     }
 }

--- a/src/main/java/com/demo/pteam/authentication/service/domain/SocialType.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/SocialType.java
@@ -29,6 +29,6 @@ public enum SocialType {
 
     public static SocialType getType(Byte code) {
         Objects.requireNonNull(code, "code is null");
-        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found SocialType");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Invalid code! Not Found SocialType");
     }
 }

--- a/src/main/java/com/demo/pteam/authentication/service/domain/SocialType.java
+++ b/src/main/java/com/demo/pteam/authentication/service/domain/SocialType.java
@@ -1,0 +1,34 @@
+package com.demo.pteam.authentication.service.domain;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum SocialType {
+    KAKAO(1),
+    NAVER(2);
+
+    private final byte code;
+    private static final Map<Byte, SocialType> CODE_MAP =
+            Arrays.stream(SocialType.values())
+                    .collect(Collectors.toUnmodifiableMap(v -> v.getCode(), Function.identity()));
+
+    SocialType(int code) {
+        this.code = (byte) code;
+    }
+
+    public Byte getCode() {
+        return code;
+    }
+
+    public static Byte getCode(SocialType type) {
+        return Objects.requireNonNull(type, "SocialType is null").getCode();
+    }
+
+    public static SocialType getType(Byte code) {
+        Objects.requireNonNull(code, "code is null");
+        return Objects.requireNonNull(CODE_MAP.get(code), "Not Found SocialType");
+    }
+}

--- a/src/main/resources/db/migration/V202504022230__accounts_column_modify.sql
+++ b/src/main/resources/db/migration/V202504022230__accounts_column_modify.sql
@@ -1,0 +1,7 @@
+ALTER TABLE local_accounts MODIFY active_username VARCHAR(20) AS(
+    IF(`status` = -1, NULL, username)
+) VIRTUAL;
+
+ALTER TABLE social_accounts MODIFY active_username_code VARCHAR(20) AS(
+    IF(`status` = -1, NULL, username_code)
+) VIRTUAL;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

> accounts 테이블 컬럼이 잘못되어서 테이블 컬럼 수정 후 계정 관련 엔티티 추가했습니다
> 엔티티 관계 설정할 때는 `AccountEntity`를 사용하시면 됩니다.
> 추가로 converter 과정에서 잘못된 `code`가 입력되거나 `null`이 입력될 경우 `NPE`가 발생하도록 구현했으니 이 점 유의하시면 되겠습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
