### PR TITLE
트레이너 프로필 단일 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     //MapStruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
@@ -76,5 +82,4 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
-    jvmArgs "-javaagent:${configurations.testRuntimeClasspath.find { it.name.contains('byte-buddy-agent') }.absolutePath}"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,6 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
     //MapStruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
@@ -68,6 +62,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// 날짜/시간 타입(JSON 직렬화 지원)
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/demo/pteam/global/config/ApplicationConfig.java
+++ b/src/main/java/com/demo/pteam/global/config/ApplicationConfig.java
@@ -1,6 +1,8 @@
 package com.demo.pteam.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +10,8 @@ import org.springframework.context.annotation.Configuration;
 public class ApplicationConfig {
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
     }
 }

--- a/src/main/java/com/demo/pteam/global/config/JpaConfig.java
+++ b/src/main/java/com/demo/pteam/global/config/JpaConfig.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class JpaConfig {
-    @Bean
-    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
-        return new JPAQueryFactory(em);
-    }
+  @Bean
+  public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+    return new JPAQueryFactory(em);
+  }
 }

--- a/src/main/java/com/demo/pteam/security/config/SecurityConfig.java
+++ b/src/main/java/com/demo/pteam/security/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auths/login").permitAll()
+                        .requestMatchers("/api/trainers/**").permitAll() // 임시
                         .anyRequest().authenticated());
 
         return http.build();

--- a/src/main/java/com/demo/pteam/trainer/address/domain/Coordinates.java
+++ b/src/main/java/com/demo/pteam/trainer/address/domain/Coordinates.java
@@ -1,9 +1,6 @@
 package com.demo.pteam.trainer.address.domain;
 
-import com.demo.pteam.global.exception.ApiException;
-import com.demo.pteam.trainer.address.exception.TrainerAddressErrorCode;
 import lombok.Getter;
-
 import java.math.BigDecimal;
 
 @Getter
@@ -12,17 +9,20 @@ public class Coordinates {
   private final BigDecimal longitude;
 
   public Coordinates(BigDecimal latitude, BigDecimal longitude) {
-    if (latitude == null || longitude == null) {
-      throw new ApiException(TrainerAddressErrorCode.COORDINATES_NULL);
-    }
-    if (latitude.abs().compareTo(BigDecimal.valueOf(90)) > 0) {
-      throw new ApiException(TrainerAddressErrorCode.INVALID_LATITUDE);
-    }
-    if (longitude.abs().compareTo(BigDecimal.valueOf(180)) > 0) {
-      throw new ApiException(TrainerAddressErrorCode.INVALID_LONGITUDE);
-    }
-
     this.latitude = latitude;
     this.longitude = longitude;
   }
+
+  public boolean isNull() {
+    return latitude == null || longitude == null;
+  }
+
+  public boolean isInvalidLatitude() {
+    return latitude != null && latitude.abs().compareTo(BigDecimal.valueOf(90)) > 0;
+  }
+
+  public boolean isInvalidLongitude() {
+    return longitude != null && longitude.abs().compareTo(BigDecimal.valueOf(180)) > 0;
+  }
+
 }

--- a/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
+++ b/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
@@ -4,13 +4,12 @@ import lombok.Getter;
 
 @Getter
 public class TrainerAddress {
-
   private final Long id;
-  private String numberAddress;
+  private final String numberAddress;
   private final String roadAddress;
   private final String detailAddress;
-  private String postalCode;
-  private Coordinates coordinates;
+  private final String postalCode;
+  private final Coordinates coordinates;
 
   public TrainerAddress(Long id, String numberAddress, String roadAddress, String detailAddress,
                         String postalCode, Coordinates coordinates) {
@@ -22,9 +21,15 @@ public class TrainerAddress {
     this.coordinates = coordinates;
   }
 
-  public void completeAddress(String numberAddress, String postalCode) {
-    this.numberAddress = numberAddress;
-    this.postalCode = postalCode;
+  public TrainerAddress withCompletedAddress(String numberAddress, String postalCode) {
+    return new TrainerAddress(
+            this.id,
+            numberAddress,
+            this.roadAddress,
+            this.detailAddress,
+            postalCode,
+            this.coordinates
+    );
   }
 
   public boolean matchesRoadAddress(String kakaoRoadAddress) {

--- a/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
+++ b/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
@@ -22,10 +22,6 @@ public class TrainerAddress {
     this.coordinates = coordinates;
   }
 
-  public static TrainerAddress from(String roadAddress, String detailAddress, Coordinates coordinates) {
-    return new TrainerAddress(null, null, roadAddress, detailAddress, null, coordinates);
-  }
-
   public void completeAddress(String numberAddress, String postalCode) {
     this.numberAddress = numberAddress;
     this.postalCode = postalCode;

--- a/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
+++ b/src/main/java/com/demo/pteam/trainer/address/domain/TrainerAddress.java
@@ -1,7 +1,5 @@
 package com.demo.pteam.trainer.address.domain;
 
-import com.demo.pteam.global.exception.ApiException;
-import com.demo.pteam.trainer.address.exception.TrainerAddressErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/demo/pteam/trainer/address/exception/TrainerAddressErrorCode.java
+++ b/src/main/java/com/demo/pteam/trainer/address/exception/TrainerAddressErrorCode.java
@@ -13,7 +13,8 @@ public enum TrainerAddressErrorCode implements ErrorCode {
     INVALID_LONGITUDE(HttpStatus.BAD_REQUEST, "L_003", "경도 값은 -180 ~ 180 사이여야 합니다."),
     ADDRESS_COORDINATE_MISMATCH(HttpStatus.BAD_REQUEST, "L_004", "위도/경도와 도로명 주소가 일치하지 않습니다."),
     KAKAO_API_EMPTY_RESPONSE(HttpStatus.BAD_GATEWAY, "L_005", "카카오 지도 API 응답이 비어있습니다."),
-    ROAD_ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "L_006", "도로명 주소를 찾을 수 없습니다.");
+    ROAD_ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "L_006", "도로명 주소를 찾을 수 없습니다."),
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "L_007", "등록되어 있는 트레이너 주소가 없습니다.");;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/demo/pteam/trainer/address/mapper/TrainerAddressMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/address/mapper/TrainerAddressMapper.java
@@ -9,9 +9,13 @@ public class TrainerAddressMapper {
   // 요청 DTO -> 도메인 변환
   public static TrainerAddress toDomain(TrainerProfileRequest.Address dto) {
     Coordinates coordinates = new Coordinates(dto.getLatitude(), dto.getLongitude());
-    return TrainerAddress.from(
+
+    return new TrainerAddress(
+            null,
+            null,
             dto.getRoadAddress(),
             dto.getDetailAddress(),
+            null,
             coordinates
     );
   }

--- a/src/main/java/com/demo/pteam/trainer/address/mapper/TrainerAddressMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/address/mapper/TrainerAddressMapper.java
@@ -2,6 +2,7 @@ package com.demo.pteam.trainer.address.mapper;
 
 import com.demo.pteam.trainer.address.domain.Coordinates;
 import com.demo.pteam.trainer.address.domain.TrainerAddress;
+import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
 import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileRequest;
 
 public class TrainerAddressMapper {
@@ -18,6 +19,20 @@ public class TrainerAddressMapper {
             null,
             coordinates
     );
+  }
+
+  // 도메인 -> 엔티티 변환
+  public static TrainerAddressEntity toEntity(TrainerAddress address) {
+    Coordinates coordinates = address.getCoordinates();
+
+    return TrainerAddressEntity.builder()
+            .numberAddress(address.getNumberAddress())
+            .roadAddress(address.getRoadAddress())
+            .detailAddress(address.getDetailAddress())
+            .postalCode(address.getPostalCode())
+            .latitude(coordinates.getLatitude())
+            .longitude(coordinates.getLongitude())
+            .build();
   }
 
 }

--- a/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepository.java
+++ b/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepository.java
@@ -5,4 +5,5 @@ import java.util.Optional;
 
 public interface TrainerAddressRepository {
     TrainerAddress save(TrainerAddress address);
+    Optional<TrainerAddress> findById(Long addressId);
 }

--- a/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepositoryImpl.java
+++ b/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class TrainerAddressRepositoryImpl implements TrainerAddressRepository {
@@ -38,6 +40,19 @@ public class TrainerAddressRepositoryImpl implements TrainerAddressRepository {
             saved.getPostalCode(),
             coordinates
     );
+  }
+
+  @Override
+  public Optional<TrainerAddress> findById(Long addressId) {
+    return jpaRepository.findById(addressId)
+            .map(entity -> new TrainerAddress(
+                    entity.getId(),
+                    entity.getNumberAddress(),
+                    entity.getRoadAddress(),
+                    entity.getDetailAddress(),
+                    entity.getPostalCode(),
+                    new Coordinates(entity.getLatitude(), entity.getLongitude())
+            ));
   }
 
 }

--- a/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepositoryImpl.java
+++ b/src/main/java/com/demo/pteam/trainer/address/repository/TrainerAddressRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.demo.pteam.trainer.address.repository;
 
 import com.demo.pteam.trainer.address.domain.Coordinates;
 import com.demo.pteam.trainer.address.domain.TrainerAddress;
+import com.demo.pteam.trainer.address.mapper.TrainerAddressMapper;
 import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,15 +17,7 @@ public class TrainerAddressRepositoryImpl implements TrainerAddressRepository {
 
   @Override
   public TrainerAddress save(TrainerAddress address) {
-    TrainerAddressEntity entity = TrainerAddressEntity.builder()
-            .numberAddress(address.getNumberAddress())
-            .roadAddress(address.getRoadAddress())
-            .detailAddress(address.getDetailAddress())
-            .postalCode(address.getPostalCode())
-            .latitude(address.getCoordinates().getLatitude())
-            .longitude(address.getCoordinates().getLongitude())
-            .build();
-
+    TrainerAddressEntity entity = TrainerAddressMapper.toEntity(address);
     TrainerAddressEntity saved = jpaRepository.save(entity);
 
     Coordinates coordinates = new Coordinates(

--- a/src/main/java/com/demo/pteam/trainer/profile/controller/TrainerProfileController.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/controller/TrainerProfileController.java
@@ -2,29 +2,45 @@ package com.demo.pteam.trainer.profile.controller;
 
 import com.demo.pteam.global.response.ApiResponse;
 import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileRequest;
+import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileResponse;
 import com.demo.pteam.trainer.profile.service.TrainerProfileService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/trainers/me/profile")
 public class TrainerProfileController {
 
-    private final TrainerProfileService trainerProfileService;
+  private final TrainerProfileService trainerProfileService;
 
-    @PostMapping
-    public ResponseEntity<ApiResponse<Void>> createProfile(
-            @RequestBody @Valid TrainerProfileRequest request
-    ) {
-        Long userId = 4L; // TODO: 로그인 사용자 임시
+  /**
+   * 트레이너 프로필 등록 API
+   * @param request 트레이너 프로필 요청 DTO
+   * @return 등록 성공 여부
+   */
+  @PostMapping
+  public ResponseEntity<ApiResponse<Void>> createProfile(
+          @RequestBody @Valid TrainerProfileRequest request
+  ) {
+    Long userId = 4L; // TODO: 로그인 사용자 임시
 
-        trainerProfileService.createProfile(request, userId);
-        return ResponseEntity.status(201).body(ApiResponse.created("트레이너 프로필이 성공적으로 등록되었습니다."));
-    }
+    trainerProfileService.createProfile(request, userId);
+    return ResponseEntity.status(201).body(ApiResponse.created("트레이너 프로필이 성공적으로 등록되었습니다."));
+  }
+
+  /**
+   * 트레이너 프로필 조회 API (사용자 본인)
+   * @return 트레이너 프로필 응답 DTO
+   */
+  @GetMapping
+  public ResponseEntity<ApiResponse<TrainerProfileResponse>> getProfile() {
+    Long userId = 4L; // TODO: 로그인 사용자 임시
+
+    TrainerProfileResponse response = trainerProfileService.getProfile(userId);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileRequest.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileRequest.java
@@ -1,5 +1,6 @@
 package com.demo.pteam.trainer.profile.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -23,7 +24,10 @@ public class TrainerProfileRequest {
     @PositiveOrZero(message = "크레딧은 0 이상이어야 합니다.")
     private Integer credit;
 
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime contactStartTime;
+
+    @JsonFormat(pattern = "HH:mm")
     private LocalTime contactEndTime;
 
     @NotNull(message = "이름 공개 선택 여부는 필수입니다.")

--- a/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileResponse.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileResponse.java
@@ -1,5 +1,39 @@
 package com.demo.pteam.trainer.profile.controller.dto;
 
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TrainerProfileResponse {
+  private Long profileId;
+  private String displayName;
+  private String intro;
+  private Integer credit;
+  private LocalTime contactStartTime;
+  private LocalTime contactEndTime;
+  private String profileImg;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  private Address address;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class Address {
+    private String roadAddress;
+    private String detailAddress;
+    private String postalCode;
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+  }
 
 }
+

--- a/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileResponse.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/controller/dto/TrainerProfileResponse.java
@@ -1,5 +1,6 @@
 package com.demo.pteam.trainer.profile.controller.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 
 import java.math.BigDecimal;
@@ -15,10 +16,18 @@ public class TrainerProfileResponse {
   private String displayName;
   private String intro;
   private Integer credit;
+
+  @JsonFormat(pattern = "HH:mm")
   private LocalTime contactStartTime;
+
+  @JsonFormat(pattern = "HH:mm")
   private LocalTime contactEndTime;
   private String profileImg;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime createdAt;
+
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
   private LocalDateTime updatedAt;
 
   private Address address;

--- a/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
@@ -34,13 +34,6 @@ public class TrainerProfile {
     this.isNamePublic = isNamePublic;
   }
 
-  public static TrainerProfile of(Long userId, String name, String nickname, Long addressId, String profileImg,
-                                  String intro, Integer credit,
-                                  LocalTime contactStartTime, LocalTime contactEndTime, Boolean isNamePublic) {
-    return new TrainerProfile(null, userId, name, nickname, addressId, profileImg, intro, credit,
-            contactStartTime, contactEndTime, isNamePublic);
-  }
-
   public String getDisplayName() {
     return isNamePublic ? name : nickname;
   }

--- a/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
@@ -1,9 +1,6 @@
 package com.demo.pteam.trainer.profile.domain;
 
-import com.demo.pteam.global.exception.ApiException;
-import com.demo.pteam.trainer.profile.exception.TrainerProfileErrorCode;
 import lombok.Getter;
-
 import java.time.LocalTime;
 
 @Getter
@@ -11,6 +8,8 @@ public class TrainerProfile {
 
   private final Long id;
   private final Long userId;
+  private final String name;
+  private final String nickname;
   private final Long addressId;
   private final String profileImg;
   private final String intro;
@@ -19,10 +18,13 @@ public class TrainerProfile {
   private final LocalTime contactEndTime;
   private final Boolean isNamePublic;
 
-  public TrainerProfile(Long id, Long userId, Long addressId, String profileImg, String intro, Integer credit,
+  public TrainerProfile(Long id, Long userId, String name, String nickname, Long addressId,
+                        String profileImg, String intro, Integer credit,
                         LocalTime contactStartTime, LocalTime contactEndTime, Boolean isNamePublic) {
     this.id = id;
     this.userId = userId;
+    this.name = name;
+    this.nickname = nickname;
     this.addressId = addressId;
     this.profileImg = profileImg;
     this.intro = intro;
@@ -32,14 +34,15 @@ public class TrainerProfile {
     this.isNamePublic = isNamePublic;
   }
 
-  public static TrainerProfile of(Long userId, Long addressId, String profileImg, String intro, Integer credit,
+  public static TrainerProfile of(Long userId, String name, String nickname, Long addressId, String profileImg,
+                                  String intro, Integer credit,
                                   LocalTime contactStartTime, LocalTime contactEndTime, Boolean isNamePublic) {
-    return new TrainerProfile(null, userId, addressId, profileImg, intro, credit,
+    return new TrainerProfile(null, userId, name, nickname, addressId, profileImg, intro, credit,
             contactStartTime, contactEndTime, isNamePublic);
   }
 
-  public boolean isNameVisible() {
-    return this.isNamePublic;
+  public String getDisplayName() {
+    return isNamePublic ? name : nickname;
   }
 
   public boolean isContactTimePairValid() {

--- a/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/domain/TrainerProfile.java
@@ -38,21 +38,13 @@ public class TrainerProfile {
     return isNamePublic ? name : nickname;
   }
 
-  public boolean isContactTimePairValid() {
-    return (contactStartTime == null && contactEndTime == null) ||
-            (contactStartTime != null && contactEndTime != null);
+  public boolean isInvalidContactTimePair() {
+    return !(contactStartTime == null && contactEndTime == null) &&
+            !(contactStartTime != null && contactEndTime != null);
   }
 
-  public boolean hasContactTime() {
-    return contactStartTime != null && contactEndTime != null;
-  }
-
-  public boolean isValidContatTimeRange() {
-    return hasContactTime() && !contactStartTime.isAfter(contactEndTime);
-  }
-
-  public boolean isProfileComplete() {
-    return userId != null && isNamePublic != null;
+  public boolean isInvalidContactTimeRange() {
+    return contactStartTime != null && contactEndTime != null && contactStartTime.isAfter(contactEndTime);
   }
 
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/exception/TrainerProfileErrorCode.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/exception/TrainerProfileErrorCode.java
@@ -10,7 +10,8 @@ public enum TrainerProfileErrorCode implements ErrorCode {
     PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "P_001", "존재하지 않는 트레이너 프로필입니다."),
     PROFILE_INCOMPLETE(HttpStatus.BAD_REQUEST, "P_002", "User ID와 이름 공개 여부(isNamePublic)는 필수입니다."),
     INVALID_CONTACT_TIME_PAIR(HttpStatus.BAD_REQUEST, "P_003", "연락 시작 시간과 종료 시간은 모두 입력하거나 모두 생략해야 합니다."),
-    INVALID_CONTACT_TIME_RANGE(HttpStatus.BAD_REQUEST, "P_004", "연락 시작 시간이 종료 시간보다 늦을 수 없습니다.");
+    INVALID_CONTACT_TIME_RANGE(HttpStatus.BAD_REQUEST, "P_004", "연락 시작 시간이 종료 시간보다 늦을 수 없습니다."),
+    TRAINER_ROLE_REQUIRED(HttpStatus.FORBIDDEN, "P_005", "트레이너 권한이 필요합니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
@@ -2,13 +2,17 @@ package com.demo.pteam.trainer.profile.mapper;
 
 
 import com.demo.pteam.authentication.repository.entity.AccountEntity;
+import com.demo.pteam.trainer.address.domain.TrainerAddress;
 import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
+import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileResponse;
 import com.demo.pteam.trainer.profile.domain.TrainerProfile;
 import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
 
+import java.time.LocalDateTime;
+
 public class TrainerProfileMapper {
 
-  // 프로필 도메인 -> 프로필 엔티티 변환
+  // 프로필 도메인 -> 프로필 엔티티
   public static TrainerProfileEntity toEntity(
           TrainerProfile profile,
           AccountEntity trainer,
@@ -23,6 +27,45 @@ public class TrainerProfileMapper {
             .contactStartTime(profile.getContactStartTime())
             .contactEndTime(profile.getContactEndTime())
             .isNamePublic(profile.getIsNamePublic())
+            .build();
+  }
+
+  // 프로필 엔티티 -> 프로필 도메인
+  public static TrainerProfile toDomain(TrainerProfileEntity entity) {
+    return new TrainerProfile(
+            entity.getId(),
+            entity.getTrainer().getId(),
+            entity.getTrainer().getName(),
+            entity.getTrainer().getNickname(),
+            entity.getAddress().getId(),
+            entity.getProfileImg(),
+            entity.getIntro(),
+            entity.getCredit(),
+            entity.getContactStartTime(),
+            entity.getContactEndTime(),
+            entity.getIsNamePublic()
+    );
+  }
+
+  // 프로필 도메인 -> 프로필 응답 DTO
+  public static TrainerProfileResponse toResponse(TrainerProfile profile, TrainerAddress address, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    return TrainerProfileResponse.builder()
+            .profileId(profile.getId())
+            .displayName(profile.getDisplayName())
+            .intro(profile.getIntro())
+            .credit(profile.getCredit())
+            .contactStartTime(profile.getContactStartTime())
+            .contactEndTime(profile.getContactEndTime())
+            .profileImg(profile.getProfileImg())
+            .createdAt(createdAt)
+            .updatedAt(updatedAt)
+            .address(TrainerProfileResponse.Address.builder()
+                    .roadAddress(address.getRoadAddress())
+                    .detailAddress(address.getDetailAddress())
+                    .postalCode(address.getPostalCode())
+                    .latitude(address.getCoordinates().getLatitude())
+                    .longitude(address.getCoordinates().getLongitude())
+                    .build())
             .build();
   }
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
@@ -1,0 +1,28 @@
+package com.demo.pteam.trainer.profile.mapper;
+
+
+import com.demo.pteam.authentication.repository.entity.AccountEntity;
+import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
+import com.demo.pteam.trainer.profile.domain.TrainerProfile;
+import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
+
+public class TrainerProfileMapper {
+
+  // 프로필 도메인 -> 프로필 엔티티 변환
+  public static TrainerProfileEntity toEntity(
+          TrainerProfile profile,
+          AccountEntity trainer,
+          TrainerAddressEntity address) {
+
+    return TrainerProfileEntity.builder()
+            .trainer(trainer)
+            .address(address)
+            .profileImg(profile.getProfileImg())
+            .intro(profile.getIntro())
+            .credit(profile.getCredit())
+            .contactStartTime(profile.getContactStartTime())
+            .contactEndTime(profile.getContactEndTime())
+            .isNamePublic(profile.getIsNamePublic())
+            .build();
+  }
+}

--- a/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
@@ -4,6 +4,7 @@ package com.demo.pteam.trainer.profile.mapper;
 import com.demo.pteam.authentication.repository.entity.AccountEntity;
 import com.demo.pteam.trainer.address.domain.TrainerAddress;
 import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
+import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileRequest;
 import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileResponse;
 import com.demo.pteam.trainer.profile.domain.TrainerProfile;
 import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
@@ -67,5 +68,22 @@ public class TrainerProfileMapper {
                     .longitude(address.getCoordinates().getLongitude())
                     .build())
             .build();
+  }
+
+  // 요청 DTO -> 도메인
+  public static TrainerProfile toDomain(TrainerProfileRequest dto, Long userId, Long addressId) {
+    return new TrainerProfile(
+            null,
+            userId,
+            null,
+            null,
+            addressId,
+            dto.getProfileImg(),
+            dto.getIntro(),
+            dto.getCredit(),
+            dto.getContactStartTime(),
+            dto.getContactEndTime(),
+            dto.getIsNamePublic()
+    );
   }
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/mapper/TrainerProfileMapper.java
@@ -70,7 +70,7 @@ public class TrainerProfileMapper {
             .build();
   }
 
-  // 요청 DTO -> 도메인
+  // 프로필 요청 DTO -> 프로필 도메인
   public static TrainerProfile toDomain(TrainerProfileRequest dto, Long userId, Long addressId) {
     return new TrainerProfile(
             null,

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepository.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepository.java
@@ -3,5 +3,5 @@ package com.demo.pteam.trainer.profile.repository;
 import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface TrainerProfileJPARepository extends JpaRepository<TrainerProfileEntity, Long> {
+public interface TrainerProfileJPARepository extends JpaRepository<TrainerProfileEntity, Long>, TrainerProfileJPARepositoryCustom {
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepositoryCustom.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.demo.pteam.trainer.profile.repository;
+
+import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
+
+import java.util.Optional;
+
+public interface TrainerProfileJPARepositoryCustom {
+  Optional<TrainerProfileEntity> findDetailedProfileEntityByUserId(Long userId);
+}

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepositoryCustomImpl.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileJPARepositoryCustomImpl.java
@@ -1,0 +1,34 @@
+package com.demo.pteam.trainer.profile.repository;
+
+import com.demo.pteam.authentication.repository.entity.QAccountEntity;
+import com.demo.pteam.trainer.address.repository.entity.QTrainerAddressEntity;
+import com.demo.pteam.trainer.profile.repository.entity.QTrainerProfileEntity;
+import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class TrainerProfileJPARepositoryCustomImpl implements TrainerProfileJPARepositoryCustom {
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Optional<TrainerProfileEntity> findDetailedProfileEntityByUserId(Long userId) {
+    QTrainerProfileEntity profile = QTrainerProfileEntity.trainerProfileEntity;
+    QTrainerAddressEntity address = QTrainerAddressEntity.trainerAddressEntity;
+    QAccountEntity account = QAccountEntity.accountEntity;
+
+    return Optional.ofNullable(
+            queryFactory
+                    .select(profile)
+                    .from(profile)
+                    .leftJoin(profile.address, address).fetchJoin()
+                    .leftJoin(profile.trainer, account).fetchJoin()
+                    .where(profile.trainer.id.eq(userId))
+                    .fetchOne()
+    );
+  }
+}

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepository.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepository.java
@@ -1,7 +1,11 @@
 package com.demo.pteam.trainer.profile.repository;
 
 import com.demo.pteam.trainer.profile.domain.TrainerProfile;
+import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
+
+import java.util.Optional;
 
 public interface TrainerProfileRepository {
     void save(TrainerProfile trainerProfile);
+    Optional<TrainerProfileEntity> findEntityByUserId(Long userId);
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepositoryImpl.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepositoryImpl.java
@@ -3,35 +3,29 @@ package com.demo.pteam.trainer.profile.repository;
 import com.demo.pteam.authentication.repository.entity.AccountEntity;
 import com.demo.pteam.trainer.address.repository.entity.TrainerAddressEntity;
 import com.demo.pteam.trainer.profile.domain.TrainerProfile;
+import com.demo.pteam.trainer.profile.mapper.TrainerProfileMapper;
 import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @RequiredArgsConstructor
 @Repository
 public class TrainerProfileRepositoryImpl implements TrainerProfileRepository {
 
-    private final TrainerProfileJPARepository trainerProfileJPARepository;
-    private final EntityManager em;
+  private final TrainerProfileJPARepository trainerProfileJPARepository;
+  private final EntityManager em;
 
-    @Override
-    public void save(TrainerProfile profile) {
+  @Override
+  public void save(TrainerProfile profile) {
 
-        AccountEntity trainer = em.getReference(AccountEntity.class, profile.getUserId());
-        TrainerAddressEntity address = em.getReference(TrainerAddressEntity.class, profile.getAddressId());
+    AccountEntity trainer = em.getReference(AccountEntity.class, profile.getUserId());
+    TrainerAddressEntity address = em.getReference(TrainerAddressEntity.class, profile.getAddressId());
 
-        TrainerProfileEntity entity = TrainerProfileEntity.builder()
-                .trainer(trainer)
-                .address(address)
-                .profileImg(profile.getProfileImg())
-                .intro(profile.getIntro())
-                .credit(profile.getCredit())
-                .contactStartTime(profile.getContactStartTime())
-                .contactEndTime(profile.getContactEndTime())
-                .isNamePublic(profile.getIsNamePublic())
-                .build();
+    TrainerProfileEntity entity = TrainerProfileMapper.toEntity(profile, trainer, address);
+    trainerProfileJPARepository.save(entity);
+  }
 
-        trainerProfileJPARepository.save(entity);
-    }
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepositoryImpl.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/TrainerProfileRepositoryImpl.java
@@ -28,4 +28,9 @@ public class TrainerProfileRepositoryImpl implements TrainerProfileRepository {
     trainerProfileJPARepository.save(entity);
   }
 
+  @Override
+  public Optional<TrainerProfileEntity> findEntityByUserId(Long userId) {
+    return trainerProfileJPARepository.findDetailedProfileEntityByUserId(userId);
+  }
+
 }

--- a/src/main/java/com/demo/pteam/trainer/profile/repository/entity/TrainerProfileEntity.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/repository/entity/TrainerProfileEntity.java
@@ -22,7 +22,7 @@ public class TrainerProfileEntity extends SoftDeletableEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private AccountEntity trainer;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
@@ -62,18 +62,7 @@ public class TrainerProfileService {
     TrainerAddress savedAddress = trainerAddressRepository.save(newAddress);
 
     // name, nickname 임시
-    TrainerProfile profile = TrainerProfile.of(
-            userId,
-            null,
-            null,
-            savedAddress.getId(),
-            request.getProfileImg(),
-            request.getIntro(),
-            request.getCredit(),
-            request.getContactStartTime(),
-            request.getContactEndTime(),
-            request.getIsNamePublic()
-    );
+    TrainerProfile profile = TrainerProfileMapper.toDomain(request, userId, savedAddress.getId());
 
     if (!profile.isProfileComplete()) {
       throw new ApiException(TrainerProfileErrorCode.PROFILE_INCOMPLETE);

--- a/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
@@ -16,14 +16,12 @@ import com.demo.pteam.trainer.profile.mapper.TrainerProfileMapper;
 import com.demo.pteam.trainer.profile.repository.TrainerProfileRepository;
 import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
-@Slf4j
 public class TrainerProfileService {
 
   private final TrainerProfileRepository trainerProfileRepository;
@@ -37,18 +35,6 @@ public class TrainerProfileService {
    */
   public void createProfile(TrainerProfileRequest request, Long userId) {
     // TODO: '회원'이 아닌 '트레이너' 확인 여부
-    log.info("📌 profileImg = {}", request.getProfileImg());
-    log.info("📌 intro = {}", request.getIntro());
-    log.info("📌 credit = {}", request.getCredit());
-    log.info("📌 contactStartTime = {}", request.getContactStartTime());
-    log.info("📌 contactEndTime = {}", request.getContactEndTime());
-    log.info("📌 isNamePublic = {}", request.getIsNamePublic());
-
-    TrainerProfileRequest.Address addr = request.getAddress();
-    log.info("📍 address.roadAddress = {}", addr.getRoadAddress());
-    log.info("📍 address.detailAddress = {}", addr.getDetailAddress());
-    log.info("📍 address.latitude = {}", addr.getLatitude());
-    log.info("📍 address.longitude = {}", addr.getLongitude());
 
     TrainerAddress newAddress = TrainerAddressMapper.toDomain(request.getAddress());
 
@@ -92,6 +78,7 @@ public class TrainerProfileService {
     if (profile.isInvalidContactTimePair()) {
       throw new ApiException(TrainerProfileErrorCode.INVALID_CONTACT_TIME_PAIR);
     }
+
     if (profile.isInvalidContactTimeRange()) {
       throw new ApiException(TrainerProfileErrorCode.INVALID_CONTACT_TIME_RANGE);
     }

--- a/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
+++ b/src/main/java/com/demo/pteam/trainer/profile/service/TrainerProfileService.java
@@ -8,23 +8,34 @@ import com.demo.pteam.trainer.address.exception.TrainerAddressErrorCode;
 import com.demo.pteam.trainer.address.mapper.TrainerAddressMapper;
 import com.demo.pteam.trainer.address.repository.TrainerAddressRepository;
 import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileRequest;
+import com.demo.pteam.trainer.profile.controller.dto.TrainerProfileResponse;
 import com.demo.pteam.trainer.profile.domain.TrainerProfile;
 import com.demo.pteam.trainer.profile.exception.TrainerProfileErrorCode;
+import com.demo.pteam.trainer.profile.mapper.TrainerProfileMapper;
 import com.demo.pteam.trainer.profile.repository.TrainerProfileRepository;
+import com.demo.pteam.trainer.profile.repository.entity.TrainerProfileEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class TrainerProfileService {
 
   private final TrainerProfileRepository trainerProfileRepository;
   private final TrainerAddressRepository trainerAddressRepository;
   private final KakaoMapService kakaoMapService;
 
-  @Transactional
+  /**
+   * 트레이너 프로필 등록
+   * @param request 트레이너 프로필 DTO
+   * @param userId 로그인 사용자 id
+   */
   public void createProfile(TrainerProfileRequest request, Long userId) {
+    // TODO: '회원'이 아닌 '트레이너' 확인 여부
 
     TrainerAddress newAddress = TrainerAddressMapper.toDomain(request.getAddress());
 
@@ -50,8 +61,11 @@ public class TrainerProfileService {
 
     TrainerAddress savedAddress = trainerAddressRepository.save(newAddress);
 
+    // name, nickname 임시
     TrainerProfile profile = TrainerProfile.of(
             userId,
+            null,
+            null,
             savedAddress.getId(),
             request.getProfileImg(),
             request.getIntro(),
@@ -74,6 +88,26 @@ public class TrainerProfileService {
     }
 
     trainerProfileRepository.save(profile);
+  }
+
+  /**
+   * 트레이너 프로필 조회 API (사용자 본인)
+   * @return 트레이너 프로필 응답 DTO
+   */
+  @Transactional(readOnly = true)
+  public TrainerProfileResponse getProfile(Long userId) {
+    // TODO: '회원'이 아닌 '트레이너' 확인 여부
+
+    // 로그인한 사용자의 프로필이 있는지 여부
+    TrainerProfileEntity entity = trainerProfileRepository.findEntityByUserId(userId)
+            .orElseThrow(() -> new ApiException(TrainerProfileErrorCode.PROFILE_NOT_FOUND));
+
+    TrainerProfile profile = TrainerProfileMapper.toDomain(entity);
+
+    TrainerAddress address = trainerAddressRepository.findById(profile.getAddressId())
+            .orElseThrow(() -> new ApiException(TrainerAddressErrorCode.ADDRESS_NOT_FOUND));
+
+    return TrainerProfileMapper.toResponse(profile, address, entity.getCreatedAt(), entity.getUpdatedAt());
   }
 
 }

--- a/src/main/resources/db/migration/V202505241925__add_trainer_user_unique_constraint.sql
+++ b/src/main/resources/db/migration/V202505241925__add_trainer_user_unique_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE trainer_profile ADD CONSTRAINT uq_trainer_user UNIQUE (user_id);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #43 

## 📝작업 내용

> TrainerProfileResponse 작성 (자격증, 해시태그 미적용 / API 명세서 확인)
> QueryDSL 의존성 추가 및 JpaConfig 파일 등록 (민형님과 동일)
> 트레이너 프로필 단일 조회 (로그인한 트레이너 기준)

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/6b26740b-1d7e-4c54-aa6f-2d61703adc24)

## 💬리뷰 요구사항(선택)
> userId는 현재 4L, 임의의 값으로 두었습니다.
